### PR TITLE
implement lower casing first character and symbols, add more test cases

### DIFF
--- a/spec/fast_camelize_spec.rb
+++ b/spec/fast_camelize_spec.rb
@@ -9,13 +9,45 @@ RSpec.describe FastCamelize do
     "漢_字_😊_🎉"            => "漢字😊🎉"
   }
 
+  SymbolToLowerCamel = {
+    product: "product",
+    special_guest: "specialGuest",
+    application_controller: "applicationController",
+    area51_controller: "area51Controller"
+  }
+
+  ACRONYMS = ["API", "HTML", "JSON"]
+  ACRONYM_WITH_OVERRIDE = ["API", "LegacyApi"]
+
+  UnderscoreToLowerCamelWithAcronyms = {
+    "html_api" => "htmlAPI",
+    "htmlAPI" => "htmlAPI",
+    "HTMLAPI" => "htmlAPI",
+  }
+
+  UnderscoreToCamelAcronymSequence = {
+    "json_html_api" => "JSONHTMLAPI"
+  }
+
   UnderscoreToCamel.each do |input, output|
     it "camelizes #{input}" do
-      expect(FastCamelize.camelize(input, true, [], 0)).to eq output
+      expect(FastCamelize.camelize(input, true, [])).to eq output
     end
   end
 
   it "downcases the first letter" do
-    expect(FastCamelize.camelize("Capital", false, [], 0)).to eq "capital"
+    expect(FastCamelize.camelize("Capital", false, [])).to eq "capital"
+  end
+
+  SymbolToLowerCamel.each do |input, output|
+    it "lower camels symbol #{input}" do
+      expect(FastCamelize.camelize(input, false, [])).to eq output
+    end
+  end
+
+  UnderscoreToLowerCamelWithAcronyms.each do |input, output|
+    it "camelizes #{input} respecting the acronyms" do
+      expect(FastCamelize.camelize(input, false, ['asdf', '123'])).to eq output
+    end
   end
 end


### PR DESCRIPTION
Learned that we don't need to pass array size so removed that argument too. 

Also, did a little allocation golfing, builder is a local stack variable and if the string is small enough we can use a local buffer instead of mallocing. Probably needless but we're here so why not.